### PR TITLE
Bump pyarrow dependency to 0.7.*

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,10 @@
 version: 2
 
 jobs:
-  build__CONDA_NPY_111__CONDA_PY_27:
+  build__CONDA_PY_27:
     working_directory: ~/test
     machine: true
     environment:
-      - CONDA_NPY: "111"
       - CONDA_PY: "27"
     steps:
       - checkout
@@ -19,62 +18,14 @@ jobs:
       - run:
           name: Print conda-build environment variables
           command: |
-            echo "CONDA_NPY=${CONDA_NPY}"
             echo "CONDA_PY=${CONDA_PY}"
       - run:
           # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
           command: ./ci_support/run_docker_build.sh
-  build__CONDA_NPY_112__CONDA_PY_27:
+  build__CONDA_PY_35:
     working_directory: ~/test
     machine: true
     environment:
-      - CONDA_NPY: "112"
-      - CONDA_PY: "27"
-    steps:
-      - checkout
-      - run:
-          name: Fast finish outdated PRs and merge PRs
-          command: |
-            ./ci_support/fast_finish_ci_pr_build.sh
-            ./ci_support/checkout_merge_commit.sh
-      - run:
-          command: docker pull condaforge/linux-anvil
-      - run:
-          name: Print conda-build environment variables
-          command: |
-            echo "CONDA_NPY=${CONDA_NPY}"
-            echo "CONDA_PY=${CONDA_PY}"
-      - run:
-          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
-          command: ./ci_support/run_docker_build.sh
-  build__CONDA_NPY_113__CONDA_PY_27:
-    working_directory: ~/test
-    machine: true
-    environment:
-      - CONDA_NPY: "113"
-      - CONDA_PY: "27"
-    steps:
-      - checkout
-      - run:
-          name: Fast finish outdated PRs and merge PRs
-          command: |
-            ./ci_support/fast_finish_ci_pr_build.sh
-            ./ci_support/checkout_merge_commit.sh
-      - run:
-          command: docker pull condaforge/linux-anvil
-      - run:
-          name: Print conda-build environment variables
-          command: |
-            echo "CONDA_NPY=${CONDA_NPY}"
-            echo "CONDA_PY=${CONDA_PY}"
-      - run:
-          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
-          command: ./ci_support/run_docker_build.sh
-  build__CONDA_NPY_111__CONDA_PY_35:
-    working_directory: ~/test
-    machine: true
-    environment:
-      - CONDA_NPY: "111"
       - CONDA_PY: "35"
     steps:
       - checkout
@@ -88,62 +39,14 @@ jobs:
       - run:
           name: Print conda-build environment variables
           command: |
-            echo "CONDA_NPY=${CONDA_NPY}"
             echo "CONDA_PY=${CONDA_PY}"
       - run:
           # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
           command: ./ci_support/run_docker_build.sh
-  build__CONDA_NPY_112__CONDA_PY_35:
+  build__CONDA_PY_36:
     working_directory: ~/test
     machine: true
     environment:
-      - CONDA_NPY: "112"
-      - CONDA_PY: "35"
-    steps:
-      - checkout
-      - run:
-          name: Fast finish outdated PRs and merge PRs
-          command: |
-            ./ci_support/fast_finish_ci_pr_build.sh
-            ./ci_support/checkout_merge_commit.sh
-      - run:
-          command: docker pull condaforge/linux-anvil
-      - run:
-          name: Print conda-build environment variables
-          command: |
-            echo "CONDA_NPY=${CONDA_NPY}"
-            echo "CONDA_PY=${CONDA_PY}"
-      - run:
-          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
-          command: ./ci_support/run_docker_build.sh
-  build__CONDA_NPY_113__CONDA_PY_35:
-    working_directory: ~/test
-    machine: true
-    environment:
-      - CONDA_NPY: "113"
-      - CONDA_PY: "35"
-    steps:
-      - checkout
-      - run:
-          name: Fast finish outdated PRs and merge PRs
-          command: |
-            ./ci_support/fast_finish_ci_pr_build.sh
-            ./ci_support/checkout_merge_commit.sh
-      - run:
-          command: docker pull condaforge/linux-anvil
-      - run:
-          name: Print conda-build environment variables
-          command: |
-            echo "CONDA_NPY=${CONDA_NPY}"
-            echo "CONDA_PY=${CONDA_PY}"
-      - run:
-          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
-          command: ./ci_support/run_docker_build.sh
-  build__CONDA_NPY_111__CONDA_PY_36:
-    working_directory: ~/test
-    machine: true
-    environment:
-      - CONDA_NPY: "111"
       - CONDA_PY: "36"
     steps:
       - checkout
@@ -157,53 +60,6 @@ jobs:
       - run:
           name: Print conda-build environment variables
           command: |
-            echo "CONDA_NPY=${CONDA_NPY}"
-            echo "CONDA_PY=${CONDA_PY}"
-      - run:
-          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
-          command: ./ci_support/run_docker_build.sh
-  build__CONDA_NPY_112__CONDA_PY_36:
-    working_directory: ~/test
-    machine: true
-    environment:
-      - CONDA_NPY: "112"
-      - CONDA_PY: "36"
-    steps:
-      - checkout
-      - run:
-          name: Fast finish outdated PRs and merge PRs
-          command: |
-            ./ci_support/fast_finish_ci_pr_build.sh
-            ./ci_support/checkout_merge_commit.sh
-      - run:
-          command: docker pull condaforge/linux-anvil
-      - run:
-          name: Print conda-build environment variables
-          command: |
-            echo "CONDA_NPY=${CONDA_NPY}"
-            echo "CONDA_PY=${CONDA_PY}"
-      - run:
-          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
-          command: ./ci_support/run_docker_build.sh
-  build__CONDA_NPY_113__CONDA_PY_36:
-    working_directory: ~/test
-    machine: true
-    environment:
-      - CONDA_NPY: "113"
-      - CONDA_PY: "36"
-    steps:
-      - checkout
-      - run:
-          name: Fast finish outdated PRs and merge PRs
-          command: |
-            ./ci_support/fast_finish_ci_pr_build.sh
-            ./ci_support/checkout_merge_commit.sh
-      - run:
-          command: docker pull condaforge/linux-anvil
-      - run:
-          name: Print conda-build environment variables
-          command: |
-            echo "CONDA_NPY=${CONDA_NPY}"
             echo "CONDA_PY=${CONDA_PY}"
       - run:
           # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
@@ -213,12 +69,6 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build__CONDA_NPY_111__CONDA_PY_27
-      - build__CONDA_NPY_112__CONDA_PY_27
-      - build__CONDA_NPY_113__CONDA_PY_27
-      - build__CONDA_NPY_111__CONDA_PY_35
-      - build__CONDA_NPY_112__CONDA_PY_35
-      - build__CONDA_NPY_113__CONDA_PY_35
-      - build__CONDA_NPY_111__CONDA_PY_36
-      - build__CONDA_NPY_112__CONDA_PY_36
-      - build__CONDA_NPY_113__CONDA_PY_36
+      - build__CONDA_PY_27
+      - build__CONDA_PY_35
+      - build__CONDA_PY_36

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,9 @@ osx_image: xcode6.4
 env:
   matrix:
     
-    - CONDA_NPY=111  CONDA_PY=27
-    - CONDA_NPY=112  CONDA_PY=27
-    - CONDA_NPY=113  CONDA_PY=27
-    - CONDA_NPY=111  CONDA_PY=35
-    - CONDA_NPY=112  CONDA_PY=35
-    - CONDA_NPY=113  CONDA_PY=35
-    - CONDA_NPY=111  CONDA_PY=36
-    - CONDA_NPY=112  CONDA_PY=36
-    - CONDA_NPY=113  CONDA_PY=36
+    - CONDA_PY=27
+    - CONDA_PY=35
+    - CONDA_PY=36
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "fYlNaqQMBE0fGCXONvbRJOv4Vq1F2VW75Ja2r4z/E+0kRnGamwEenA58rQNRh9gyMiQYf55Uqz6SkS12bix8p7B1gx+q0PwYPXLWRPN0FOq9q06j+fZoENLywoDsMi+9VjpvAGiI98YUXLT2WW0hNFmOB9t8jnyyBgwFSKtLtBOeotjC/nNVE9AqCIIitcCI0bXnJm0R2Jb6gnDlc87MNOKaQNWHOpKv8wRhGUF/qp1eckjIdFFq0bflPe4j712Z0Cvm0be1O/ZN4oEqMFSjGjmU8D+UVGkwiDLgZgyGGeJOp7/uYDIZ1HfpdwmHCmPisaSOLMfWPuefwOnk4MvasK4ht16POfKNv0C5rzcc1Fyq+5W0VnR03q9CPouWzjyGLJTUnOj5HaLEDXWURiaug1k5Nzm0XdY4Dk1B3fD8nAFdv5k97eWsixWg2podneeUGG6kOQdrIf5bjPkwQ7L/L3RdXZESeeOhTpnt4baDJPJ4QT6frAyxIYiTnY/QqUKc0gmXforI89AerGJvxgibs/far2c/9LitZ45brbG3/AgbY4wqes2C1uvcDJzqDlF8tdFzGSg4hsryVedHm4xHGaK/BPawKqeZNXEdI2aiFwJKTzCCWz1p0EynGgTpNpc9IqpdLTWE2wZUcuIUfNbySIt13O89+0X3ZNdeg6pje1E="

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ To manage the continuous integration and simplify feedstock maintenance
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
+For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,27 +10,10 @@ environment:
 
   matrix:
     - TARGET_ARCH: x64
-      CONDA_NPY: 111
       CONDA_PY: 35
       CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
     - TARGET_ARCH: x64
-      CONDA_NPY: 113
-      CONDA_PY: 35
-      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
-
-    - TARGET_ARCH: x64
-      CONDA_NPY: 111
-      CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
-
-    - TARGET_ARCH: x64
-      CONDA_NPY: 112
-      CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
-
-    - TARGET_ARCH: x64
-      CONDA_NPY: 113
       CONDA_PY: 36
       CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
 

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -40,7 +40,6 @@ cat << EOF | docker run -i \
                         -v "${RECIPE_ROOT}":/recipe_root \
                         -v "${FEEDSTOCK_ROOT}":/feedstock_root \
                         -e HOST_USER_ID="${HOST_USER_ID}" \
-                        -e CONDA_NPY="${CONDA_NPY}" \
                         -e CONDA_PY="${CONDA_PY}" \
                         -a stdin -a stdout -a stderr \
                         condaforge/linux-anvil \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
   build:
     - boost 1.64.*
     - cmake
-    - numpy x.x
+    - numpy 1.11.*
     - pybind11
     - python
     - setuptools
@@ -36,7 +36,7 @@ requirements:
     - pyarrow 0.7.*
   run:
     - boost 1.64.*
-    - numpy x.x
+    - numpy >=1.11
     - python
     - six
     - unixodbc  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ build:
 
 requirements:
   build:
-    - boost 1.64.*
+    - boost >=1.64
     - cmake
     - numpy 1.11.*
     - pybind11
@@ -35,7 +35,6 @@ requirements:
     - unixodbc  # [unix]
     - pyarrow 0.7.*
   run:
-    - boost 1.64.*
     - numpy >=1.11
     - python
     - six

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   patches: timezone.patch  # [win]
 
 build:
-  number: 0
+  number: 1
   # turbodbc already has set the correct RPATHs, conda relocation breaks it
   # so skip it.
   binary_relocation: False
@@ -33,14 +33,14 @@ requirements:
     - six
     - toolchain
     - unixodbc  # [unix]
-    - pyarrow 0.6.*
+    - pyarrow 0.7.*
   run:
     - boost 1.64.*
     - numpy x.x
     - python
     - six
     - unixodbc  # [unix]
-    - pyarrow 0.6.*
+    - pyarrow 0.7.*
 
 test:
   imports:


### PR DESCRIPTION
Assuming there are no breaking changes (which should be picked up by the CI) this will create a conda package which can be installed alongside the latest pyarrow.