### PR TITLE
Use arrow-cpp's run_export

### DIFF
--- a/.ci_support/linux_python2.7.yaml
+++ b/.ci_support/linux_python2.7.yaml
@@ -1,3 +1,5 @@
+arrow_cpp:
+- 0.15.0
 boost:
 - 1.70.0
 boost_cpp:

--- a/.ci_support/linux_python3.6.yaml
+++ b/.ci_support/linux_python3.6.yaml
@@ -1,3 +1,5 @@
+arrow_cpp:
+- 0.15.0
 boost:
 - 1.70.0
 boost_cpp:

--- a/.ci_support/linux_python3.7.yaml
+++ b/.ci_support/linux_python3.7.yaml
@@ -1,3 +1,5 @@
+arrow_cpp:
+- 0.15.0
 boost:
 - 1.70.0
 boost_cpp:

--- a/.ci_support/osx_python2.7.yaml
+++ b/.ci_support/osx_python2.7.yaml
@@ -1,5 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
+arrow_cpp:
+- 0.15.0
 boost:
 - 1.70.0
 boost_cpp:

--- a/.ci_support/osx_python3.6.yaml
+++ b/.ci_support/osx_python3.6.yaml
@@ -1,5 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
+arrow_cpp:
+- 0.15.0
 boost:
 - 1.70.0
 boost_cpp:

--- a/.ci_support/osx_python3.7.yaml
+++ b/.ci_support/osx_python3.7.yaml
@@ -1,5 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
+arrow_cpp:
+- 0.15.0
 boost:
 - 1.70.0
 boost_cpp:

--- a/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.6.yaml
+++ b/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.6.yaml
@@ -1,3 +1,5 @@
+arrow_cpp:
+- 0.15.0
 boost:
 - 1.70.0
 boost_cpp:

--- a/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.7.yaml
+++ b/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.7.yaml
@@ -1,3 +1,5 @@
+arrow_cpp:
+- 0.15.0
 boost:
 - 1.70.0
 boost_cpp:

--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,7 @@ bld.bat text eol=crlf
 .gitattributes linguist-generated=true
 .gitignore linguist-generated=true
 .travis.yml linguist-generated=true
+.scripts linguist-generated=true
 LICENSE.txt linguist-generated=true
 README.md linguist-generated=true
 azure-pipelines.yml linguist-generated=true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,6 @@ requirements:
     - six
     - {{ pin_compatible('numpy', lower_bound='1.16') }}
     - unixodbc  # [unix]
-    - arrow-cpp 0.15.*
     - pyarrow 0.15.*
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,8 +33,8 @@ requirements:
     - setuptools
     - six
     - unixodbc  # [unix]
-    - arrow-cpp 0.15.*
-    - pyarrow 0.15.*
+    - arrow-cpp
+    - pyarrow
   run:
     - python
     # pkg_resources is used to determine the package version
@@ -42,7 +42,7 @@ requirements:
     - six
     - {{ pin_compatible('numpy', lower_bound='1.16') }}
     - unixodbc  # [unix]
-    - pyarrow 0.15.*
+    - pyarrow
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   # turbodbc already has set the correct RPATHs, conda relocation breaks it
   # so skip it.
   binary_relocation: False


### PR DESCRIPTION
Makes sure we use `arrow-cpp`'s `run_export` to determine the version of `arrow-cpp` we use at runtime.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Fixes https://github.com/conda-forge/turbodbc-feedstock/issues/33

<!--
Please add any other relevant info below:
-->

xref: https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/321#issuecomment-550536461